### PR TITLE
Update test suite to nightly-2023-04-13

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
     async_trait_nightly_testing,
-    feature(min_specialization, type_alias_impl_trait)
+    feature(impl_trait_in_assoc_type, min_specialization)
 )]
 #![deny(rust_2021_compatibility)]
 #![allow(


### PR DESCRIPTION
    error[E0658]: `impl Trait` in associated types is unstable
        --> tests/test.rs:1297:22
         |
    1297 |         type Assoc = impl Sized;
         |                      ^^^^^^^^^^
         |
         = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable